### PR TITLE
fix: freeze arm-none-eabi-gcc version

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -31,7 +31,7 @@ jobs:
       
       - name: Install arm-none-eabi-gcc
         continue-on-error: true
-        run: xpm install @xpack-dev-tools/arm-none-eabi-gcc@latest
+        run: xpm install @xpack-dev-tools/arm-none-eabi-gcc@13.2.1-1.1.1
       
       - name: Install Zephyr SDK
         run: |

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ The following assumes that you are on an x86 machine and would like to run tests
 #### Install the xPack GNU Arm Embedded GCC
 
 * [Install `xpm`](https://xpack.github.io/xpm/install/): `npm install --global xpm@latest`
-* [Install the Arm GNU toolchain](https://xpack.github.io/dev-tools/arm-none-eabi-gcc/install/): `xpm install @xpack-dev-tools/arm-none-eabi-gcc@latest`
+* [Install the Arm GNU toolchain](https://xpack.github.io/dev-tools/arm-none-eabi-gcc/install/): `xpm install @xpack-dev-tools/arm-none-eabi-gcc@13.2.1-1.1.1`
 
 Add to your `envr-local` if the path and/or version is different from the one specified in `envr-default`:
 

--- a/envr-default
+++ b/envr-default
@@ -2,7 +2,7 @@
 PROJECT_NAME=ic-macros
 
 [VARIABLES]
-TOOLCHAIN_GNU_ARM_NONE_EABI_PATH=$HOME/.local/xPacks/@xpack-dev-tools/arm-none-eabi-gcc/12.3.1-1.2.1/.content/bin
+TOOLCHAIN_GNU_ARM_NONE_EABI_PATH=$HOME/.local/xPacks/@xpack-dev-tools/arm-none-eabi-gcc/13.2.1-1.1.1/.content/bin
 TOOLCHAIN_GNU_ARM_NONE_EABI_PREFIX=arm-none-eabi
 
 TOOLCHAIN_GNU_ARM_ZEPHYR_EABI_PATH=$HOME/zephyr-sdk-0.16.3/arm-zephyr-eabi/bin


### PR DESCRIPTION
There was a failure in the workflow caused by not locking the xpack GCC version.  I think it's OK to freeze it as long as we remember to bump it occasionally.  Very cool that the embedded toolchain is on GCC 13, has some new features!