### PR TITLE
Workflow/improve zephyr speed

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -36,11 +36,8 @@ jobs:
       - name: Install Zephyr SDK
         run: |
           cd ~
-          wget https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v0.16.3/zephyr-sdk-0.16.3_linux-x86_64.tar.xz
-          wget -O - https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v0.16.3/sha256.sum | shasum --check --ignore-missing
-          tar xf zephyr-sdk-0.16.3_linux-x86_64.tar.xz
-          cd zephyr-sdk-0.16.3
-          ./setup.sh -t arm-zephyr-eabi
+          wget https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v0.16.4/toolchain_linux-x86_64_arm-zephyr-eabi.tar.xz
+          tar -xf toolchain_linux-x86_64_arm-zephyr-eabi.tar.xz
       
       - name: Test arm-none-eabi-gcc
         run: |

--- a/README.md
+++ b/README.md
@@ -69,12 +69,8 @@ Reference: https://docs.zephyrproject.org/latest/develop/getting_started/index.h
 
 ```
 cd ~
-wget https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v0.16.3/zephyr-sdk-0.16.3_linux-x86_64.tar.xz
-wget -O - https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v0.16.3/sha256.sum | shasum --check --ignore-missing
-tar xf zephyr-sdk-0.16.3_linux-x86_64.tar.xz
-rm zephyr-sdk-0.16.3_linux-x86_64.tar.xz
-cd zephyr-sdk-0.16.3
-./setup.sh -t arm-zephyr-eabi
+wget https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v0.16.4/toolchain_linux-x86_64_arm-zephyr-eabi.tar.xz
+tar -xf toolchain_linux-x86_64_arm-zephyr-eabi.tar.xz # unpacked at ~/arm-zephyr-eabi
 
 cd ~/<back to this repository>
 ```

--- a/envr-default
+++ b/envr-default
@@ -5,7 +5,7 @@ PROJECT_NAME=ic-macros
 TOOLCHAIN_GNU_ARM_NONE_EABI_PATH=$HOME/.local/xPacks/@xpack-dev-tools/arm-none-eabi-gcc/13.2.1-1.1.1/.content/bin
 TOOLCHAIN_GNU_ARM_NONE_EABI_PREFIX=arm-none-eabi
 
-TOOLCHAIN_GNU_ARM_ZEPHYR_EABI_PATH=$HOME/zephyr-sdk-0.16.3/arm-zephyr-eabi/bin
+TOOLCHAIN_GNU_ARM_ZEPHYR_EABI_PATH=$HOME/arm-zephyr-eabi/bin
 TOOLCHAIN_GNU_ARM_ZEPHYR_EABI_PREFIX=arm-zephyr-eabi
 
 [ADD_TO_PATH]


### PR DESCRIPTION
Should speed up the Zephyr tests.  Used to take 2.5 minutes.

Edit: yep!  From 150 seconds to 8 seconds!  https://github.com/intercreate/ic-macros/actions/runs/7392276991/job/20110498945